### PR TITLE
popups

### DIFF
--- a/src/gui.rs
+++ b/src/gui.rs
@@ -415,23 +415,6 @@ fn set_random_wallpaper(_flowbox: &Rc<RefCell<FlowBox>>, image_loader: &Rc<RefCe
     }
 }
 
-#[allow(dead_code)]
-pub fn custom_info_popup(title: &str, text: &str, modal: bool) {
-    let dialog = MessageDialog::builder()
-        .message_type(gtk::MessageType::Info)
-        .buttons(gtk::ButtonsType::Ok)
-        .title(title)
-        .text(text)
-        .modal(modal)
-        .build();
-
-    dialog.connect_response(|dialog, _| {
-        dialog.close();
-    });
-
-    dialog.show();
-}
-
 pub fn custom_error_popup(title: &str, text: &str, modal: bool) {
     let dialog = MessageDialog::builder()
         .message_type(gtk::MessageType::Error)
@@ -443,23 +426,6 @@ pub fn custom_error_popup(title: &str, text: &str, modal: bool) {
 
     dialog.connect_response(|dialog, _| {
         dialog.close();
-    });
-
-    dialog.show();
-}
-
-#[allow(dead_code)]
-pub fn custom_error_popup_critical(title: &str, text: &str, modal: bool) {
-    let dialog = MessageDialog::builder()
-        .message_type(gtk::MessageType::Error)
-        .buttons(gtk::ButtonsType::Ok)
-        .title(title)
-        .text(text)
-        .modal(modal)
-        .build();
-
-    dialog.connect_response(|_, _| {
-        std::process::exit(1);
     });
 
     dialog.show();

--- a/src/gui.rs
+++ b/src/gui.rs
@@ -1,8 +1,12 @@
 use crossbeam_channel::unbounded;
 use glib::ControlFlow;
 use gtk::{
-    gdk, gdk::Texture, gdk_pixbuf::Pixbuf, gio, glib, prelude::*, Application, ApplicationWindow,
-    Box as GtkBox, Button, ComboBoxText, EventControllerMotion, FlowBox, Image, ScrolledWindow,
+    gdk::{self, Texture},
+    gdk_pixbuf::Pixbuf,
+    gio, glib,
+    prelude::*,
+    Application, ApplicationWindow, Box as GtkBox, Button, ComboBoxText, EventControllerMotion,
+    FlowBox, Image, MessageDialog, ScrolledWindow,
 };
 use parking_lot::Mutex;
 use rand::seq::SliceRandom;
@@ -409,4 +413,54 @@ fn set_random_wallpaper(_flowbox: &Rc<RefCell<FlowBox>>, image_loader: &Rc<RefCe
             }
         }
     }
+}
+
+#[allow(dead_code)]
+pub fn custom_info_popup(title: &str, text: &str, modal: bool) {
+    let dialog = MessageDialog::builder()
+        .message_type(gtk::MessageType::Info)
+        .buttons(gtk::ButtonsType::Ok)
+        .title(title)
+        .text(text)
+        .modal(modal)
+        .build();
+
+    dialog.connect_response(|dialog, _| {
+        dialog.close();
+    });
+
+    dialog.show();
+}
+
+pub fn custom_error_popup(title: &str, text: &str, modal: bool) {
+    let dialog = MessageDialog::builder()
+        .message_type(gtk::MessageType::Error)
+        .buttons(gtk::ButtonsType::Ok)
+        .title(title)
+        .text(text)
+        .modal(modal)
+        .build();
+
+    dialog.connect_response(|dialog, _| {
+        dialog.close();
+    });
+
+    dialog.show();
+}
+
+#[allow(dead_code)]
+pub fn custom_error_popup_critical(title: &str, text: &str, modal: bool) {
+    let dialog = MessageDialog::builder()
+        .message_type(gtk::MessageType::Error)
+        .buttons(gtk::ButtonsType::Ok)
+        .title(title)
+        .text(text)
+        .modal(modal)
+        .build();
+
+    dialog.connect_response(|_, _| {
+        std::process::exit(1);
+    });
+
+    dialog.show();
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,7 +33,10 @@ pub fn set_wallpaper(path: String) {
     glib::spawn_future_local(async move {
         match set_wallpaper_internal(&path).await {
             Ok(_) => println!("Wallpaper set successfully"),
-            Err(e) => eprintln!("Error setting wallpaper: {}", e),
+            Err(e) => {
+                gui::custom_error_popup("Error setting wallpaper", e.as_str(), true);
+                eprintln!("Error setting wallpaper: {}", e);
+            }
         }
     });
 }


### PR DESCRIPTION
leaving `custom_info_popup` and `custom_error_popup_critical` with `#[allow(dead_code)]` for now. might be useful in the future.