### PR TITLE
fix: hyprpaper not starting without `hyprpaper.conf`

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -27,7 +27,7 @@ An unofficial GUI for setting wallpapers with multiple backends, built with GTK4
 </div>
 
 ## Requirements
-- Hyprland with IPC enabled & hyprpaper.conf created **(only applies to hyprland / hyprpaper users)**
+- IPC enabled **(only for hyprland / hyprpaper users)**
 - any backend listed above installed
 - GTK-4 installed
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -423,6 +423,17 @@ async fn ensure_backend_running() -> Result<(), String> {
 async fn ensure_hyprpaper_running() -> Result<(), String> {
     if !is_process_running("hyprpaper").await {
         println!("hyprpaper is not running. Attempting to start it...");
+
+        let hyprpaper_config_path = tilde("~/.config/hypr/hyprpaper.conf").into_owned();
+        let hyprpaper_config_path = Path::new(&hyprpaper_config_path);
+
+        if !hyprpaper_config_path.exists() {
+            std::fs::create_dir_all(hyprpaper_config_path.parent().unwrap())
+                .expect("Failed to create ~/.config/hypr");
+            std::fs::File::create(hyprpaper_config_path)
+                .expect("Failed to create ~/.config/hypr/hyprpaper.conf");
+        }
+
         start_process("hyprpaper").await?;
     }
     Ok(())


### PR DESCRIPTION
`hyprpaper` fails if there is no config file available:
```
[LOG] Welcome to hyprpaper!
built from commit  ()
terminate called after throwing an instance of 'std::runtime_error'
  what():  Could not find config in HOME, XDG_CONFIG_HOME, XDG_CONFIG_DIRS or /etc/hypr.
[1]    16517 IOT instruction (core dumped)  hyprpaper
```

this adds a check for `~/.config/hypr/hyprpaper.conf` and creates the file (with parent dirs) if it doesn't exist
